### PR TITLE
feat: add separator_max_depth parameter and simplify separator handling

### DIFF
--- a/redis_key_analyzer/rka/cli.py
+++ b/redis_key_analyzer/rka/cli.py
@@ -19,6 +19,7 @@ from rka.redis_key_analyzer import start_redis_key_analyzer
     help="prefixes for key pattern. ex) --prefix 'prefix1 prefix2'",
 )
 @click.option("--separator", default=":", help="separators for key pattern")
+@click.option("--separator-max-depth", default=1, help="Maximum depth for separator-based pattern matching")
 @click.option("--limit", default=-1, help="Limit total keys. -1 for no limit")
 @click.option(
     "--sleep", default=-1, help="Sleep seconds between batches. -1 for no sleep"
@@ -32,11 +33,11 @@ def main(
     batch_size: int,
     prefix: str,
     separator: str,
+    separator_max_depth: int,
     limit: int,
     sleep: int,
 ) -> None:
     prefixes = re.split(r"\s+", prefix) if prefix else None
-    separators = [separator]
     start_redis_key_analyzer(
-        host, port, db, read_only, match, prefixes, separators, batch_size, limit, sleep
+        host, port, db, read_only, match, prefixes, separator, separator_max_depth, batch_size, limit, sleep
     )


### PR DESCRIPTION


### 요약
separator_max_depth 가 N 인 경우  key 에 대해서 최대 N 번째 매칭되는 부분에서 key pattern 을 추출합니다.
로직에서는 min(separator_max_depth, 실제_separator_개수) 번째에 있는 구분자가 구분자 역할을 합니다.

### example (separator_max_depth = 2 인경우)
- user:home:{userId}: 2개의 : 존재 → min(2, 2) = 2번째까지 → `user:home:<*>`
- user:office:{userId}: 2개의 : 존재 → min(2, 2) = 2번째까지 → `user:office:<*>`
- user:{userId}: 1개의 : 존재 → min(2, 1) = 1번째까지 → `user:<*>`
